### PR TITLE
Add usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
-# SecureHeaders Psr7 HttpAdapter [![Build Status](https://travis-ci.org/SecureHeaders/Psr7Adapter.svg?branch=master)](https://travis-ci.org/SecureHeaders/Psr7Adapter) [![Build Status](https://ci.appveyor.com/api/projects/status/github/secureheaders/psr7adapter?branch=master&svg=true&retina=true)](https://ci.appveyor.com/project/aidantwoods/psr7adapter)
-A Psr7 HttpAdapter implementation for [SecureHeaders](https://github.com/aidantwoods/SecureHeaders). For more information on HttpAdapters see [Framework Integration](https://github.com/aidantwoods/SecureHeaders/wiki/Framework-Integration) in the SecureHeaders Wiki.
+# SecureHeaders PSR-7 Adapter [![Build Status](https://travis-ci.org/SecureHeaders/Psr7Adapter.svg?branch=master)](https://travis-ci.org/SecureHeaders/Psr7Adapter) [![Build Status](https://ci.appveyor.com/api/projects/status/github/secureheaders/psr7adapter?branch=master&svg=true&retina=true)](https://ci.appveyor.com/project/aidantwoods/psr7adapter)
 
+A PSR-7 adapter for [SecureHeaders](https://github.com/aidantwoods/SecureHeaders).
+For more information on adapters, see [Framework Integration](https://github.com/aidantwoods/SecureHeaders/wiki/Framework-Integration) in the SecureHeaders Wiki.
+
+## Installation
+
+`composer require secureheaders/psradapter`
+
+## Usage
+
+Assuming you already have a PSR-7 response object (e.g. returned from a previous middleware) in the `$headers` variable:
+
+```php
+// Configure SecureHeaders
+$headers = new Aidantwoods\SecureHeaders\SecureHeaders;
+$headers->strictMode();
+
+// Instantiate the adapter with your response object
+$adapter = new SecureHeaders\PsrHttpAdapter\Psr7Adapter($response);
+
+// Apply your SecureHeaders configuration
+$headers->apply($adapter);
+
+// And finally retrieve the updated HTTP response object
+$response = $adapter->getFinalResponse();
+```


### PR DESCRIPTION
Makes it easier than having to jump to the wiki. :)

Once we provide a middleware implementation, that should be added as well.

Once this is merged, the [wiki page](https://github.com/aidantwoods/SecureHeaders/wiki/Framework-Integration) should probably have a link of existing (community) adapters instead of the usage instructions for PSR-7.