### PR TITLE
Make adapter throw exception on inproper use

### DIFF
--- a/src/ApplySecureHeaders.php
+++ b/src/ApplySecureHeaders.php
@@ -55,7 +55,7 @@ class ApplySecureHeaders
         $adapter  = $this->adapt($response);
 
         $headers->apply($adapter);
-        $response = $adapter->getFinalResponse();
+        $response = $adapter->getSecuredResponse();
 
         return $response;
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SecureHeaders\PsrHttpAdapter;
+
+class Exception extends \Exception
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace SecureHeaders\PsrHttpAdapter;
-
-class Exception extends \Exception
-{
-}

--- a/src/Psr7Adapter.php
+++ b/src/Psr7Adapter.php
@@ -2,8 +2,9 @@
 
 namespace SecureHeaders\PsrHttpAdapter;
 
-use Aidantwoods\SecureHeaders\Http\HttpAdapter;
 use Aidantwoods\SecureHeaders\HeaderBag;
+use Aidantwoods\SecureHeaders\Http\HttpAdapter;
+use LogicException;
 use Psr\Http\Message\ResponseInterface;
 
 class Psr7Adapter implements HttpAdapter
@@ -86,11 +87,12 @@ class Psr7Adapter implements HttpAdapter
      * @api
      *
      * @return ResponseInterface
+     * @throws LogicException if response has not been secured
      */
     public function getSecuredResponse()
     {
         if (! $this->isSecured) {
-            throw new Exception('Response has not been secured');
+            throw new LogicException('Response has not been secured');
         }
         return $this->response;
     }

--- a/src/Psr7Adapter.php
+++ b/src/Psr7Adapter.php
@@ -14,6 +14,15 @@ class Psr7Adapter implements HttpAdapter
     private $response;
 
     /**
+     * Has the response been secured?
+     *
+     * @var bool
+     *
+     * @access private
+     */
+    private $isSecured = false;
+
+    /**
      * @api
      */
     public function __construct(ResponseInterface $response)
@@ -46,6 +55,8 @@ class Psr7Adapter implements HttpAdapter
                 $header->getValue()
             );
         }
+
+        $this->isSecured = true;
     }
 
     /**
@@ -76,8 +87,11 @@ class Psr7Adapter implements HttpAdapter
      *
      * @return ResponseInterface
      */
-    public function getFinalResponse()
+    public function getSecuredResponse()
     {
+        if (! $this->isSecured) {
+            throw new Exception('Response has not been secured');
+        }
         return $this->response;
     }
 }

--- a/src/Psr7Adapter.php
+++ b/src/Psr7Adapter.php
@@ -92,7 +92,10 @@ class Psr7Adapter implements HttpAdapter
     public function getSecuredResponse()
     {
         if (! $this->isSecured) {
-            throw new LogicException('Response has not been secured');
+            throw new LogicException(
+                'Response not secured. Psr7Adapter::sendHeaders() was not called.'
+                . ' Psr7Adapter should be passed to SecureHeaders::apply()'
+            );
         }
         return $this->response;
     }

--- a/tests/ApplySecureHeadersTest.php
+++ b/tests/ApplySecureHeadersTest.php
@@ -14,15 +14,8 @@ class ApplySecureHeadersTest extends PHPUnit_Framework_TestCase
     {
         $request  = ServerRequestFactory::fromGlobals();
         $response = new Response();
-
-        $headers = $this
-            ->getMockBuilder('Aidantwoods\SecureHeaders\SecureHeaders')
-            ->getMock();
-
-        $headers->expects($this->once())
-            ->method('apply')
-            ->with($this->isInstanceOf('SecureHeaders\PsrHttpAdapter\Psr7Adapter'));
-
+        $headers  = new SecureHeaders;
+        $headers->errorReporting(false);
         $handler  = new PsrHttpAdapter\ApplySecureHeaders($headers);
 
         $next = function ($requestIn, $responseIn) use ($request, $response) {
@@ -34,7 +27,6 @@ class ApplySecureHeadersTest extends PHPUnit_Framework_TestCase
         $output = $handler($request, $response, $next);
 
         $this->assertInstanceOf('Zend\Diactoros\Response', $output);
-        $this->assertSame($response, $output);
     }
 
 }

--- a/tests/Psr7AdapterTest.php
+++ b/tests/Psr7AdapterTest.php
@@ -9,6 +9,15 @@ use Zend\Diactoros\Response;
 
 class Psr7AdapterTest extends PHPUnit_Framework_TestCase
 {
+
+    public function testThrowsException()
+    {
+        $this->setExpectedException('SecureHeaders\PsrHttpAdapter\Exception');
+        $response = new Response;
+        $adapter  = new Psr7Adapter($response);
+        $adapter->getSecuredResponse();
+    }
+
     public function testProperlyFillsHeaderBag()
     {
         $response = (new Response())
@@ -35,7 +44,7 @@ class Psr7AdapterTest extends PHPUnit_Framework_TestCase
         $adapter = new Psr7Adapter($response);
         $adapter->sendHeaders(new HeaderBag());
 
-        $finalResponse = $adapter->getFinalResponse();
+        $finalResponse = $adapter->getSecuredResponse();
 
         $this->assertEquals([], $finalResponse->getHeaders());
     }
@@ -54,7 +63,7 @@ class Psr7AdapterTest extends PHPUnit_Framework_TestCase
             'Cache-Control: no-worries :)'
         ]));
 
-        $finalResponse = $adapter->getFinalResponse();
+        $finalResponse = $adapter->getSecuredResponse();
 
         $this->assertEquals([
             'content-type' => ['text/xml'],

--- a/tests/Psr7AdapterTest.php
+++ b/tests/Psr7AdapterTest.php
@@ -12,7 +12,7 @@ class Psr7AdapterTest extends PHPUnit_Framework_TestCase
 
     public function testThrowsException()
     {
-        $this->setExpectedException('SecureHeaders\PsrHttpAdapter\Exception');
+        $this->setExpectedException('LogicException');
         $response = new Response;
         $adapter  = new Psr7Adapter($response);
         $adapter->getSecuredResponse();


### PR DESCRIPTION
- Rename `getFinalResponse` -> `getSecuredResponse`
- `getSecuredResponse` throws exception if response not secured

Thoughts on this?